### PR TITLE
timer: fix ext strip

### DIFF
--- a/images/timer-01/timer-expires-log.py
+++ b/images/timer-01/timer-expires-log.py
@@ -7,7 +7,7 @@ import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
 
-FILE_BASE = os.path.basename(__file__).rstrip('.py')
+FILE_BASE = os.path.splitext(__file__)[0]
 FILE_DATA = FILE_BASE + ".txt"
 FILE_PNG  = FILE_BASE + ".png"
 FILE_PDF  = FILE_BASE + ".pdf"

--- a/images/timer-01/timer-expires-unknown-function.py
+++ b/images/timer-01/timer-expires-unknown-function.py
@@ -6,7 +6,7 @@ import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
 
-FILE_BASE = os.path.basename(__file__).rstrip('.py')
+FILE_BASE = os.path.splitext(__file__)[0]
 FILE_DATA = FILE_BASE + ".txt"
 FILE_PNG  = FILE_BASE + ".png"
 FILE_PDF  = FILE_BASE + ".pdf"

--- a/images/timer-01/timer-expires.py
+++ b/images/timer-01/timer-expires.py
@@ -7,7 +7,7 @@ import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
 
-FILE_BASE = os.path.basename(__file__).rstrip('.py')
+FILE_BASE = os.path.splitext(__file__)[0]
 FILE_DATA = FILE_BASE + ".txt"
 FILE_PNG  = FILE_BASE + ".png"
 FILE_PDF  = FILE_BASE + ".pdf"

--- a/images/timer-01/timer-type-callback-expiration-bar.py
+++ b/images/timer-01/timer-type-callback-expiration-bar.py
@@ -6,7 +6,7 @@ import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
 
-FILE_BASE = os.path.basename(__file__).rstrip('.py')
+FILE_BASE = os.path.splitext(__file__)[0]
 FILE_DATA = FILE_BASE + ".txt"
 FILE_PNG  = FILE_BASE + ".png"
 FILE_PDF  = FILE_BASE + ".pdf"

--- a/images/timer-01/timer-type-callback-expiration-pie.py
+++ b/images/timer-01/timer-type-callback-expiration-pie.py
@@ -6,7 +6,7 @@ import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
 
-FILE_BASE = os.path.basename(__file__).rstrip('.py')
+FILE_BASE = os.path.splitext(__file__)[0]
 FILE_DATA = FILE_BASE + ".txt"
 FILE_PNG  = FILE_BASE + ".png"
 FILE_PDF  = FILE_BASE + ".pdf"


### PR DESCRIPTION
**Issues:**

1. Characters at the end of the filename with '.', 'p', or 'y' at the end of their name are also stripped by `rstrip`.
2. `basename`, which strips the path of all directories, denies any calls except for calls originating from the directory the script resides in.

**Examples**

1. `'timemappy.py'.rstrip('.py')` transforms the string to `'timema'`
2.  `$perf-power-statistics-doc/images ./timer-01/timer-type-callback-expiration-pie.py` 
`FileNotFoundError: [Errno 2] No such file or directory: 'timer-type-callback-expiration-pie.txt'` 

**Suggested Solution:**

1. Use `splitext` instead of `rstrip`
2. Remove `basename`